### PR TITLE
Mark failing tests as such

### DIFF
--- a/t/list-untracked.t
+++ b/t/list-untracked.t
@@ -71,7 +71,8 @@ test_expect_success 'list-untracked works with one empty repo' \
 	$VCSH list-untracked >output &&
 	test_cmp expected output'
 
-test_expect_success 'list-untracked -r works with one empty repo' \
+# Bug
+test_expect_failure 'list-untracked -r works with one empty repo' \
 	'{
 		echo a &&
 		echo b &&
@@ -101,7 +102,8 @@ test_expect_success 'list-untracked shows completely untracked directory' \
 	'$VCSH list-untracked >output &&
 	test_grep -Fx untracked/ <output'
 
-test_expect_success 'list-untracked -r shows contents of completely untracked directory' \
+# Bug
+test_expect_failure 'list-untracked -r shows contents of completely untracked directory' \
 	'$VCSH list-untracked -r >output &&
 	test_grep -Fx untracked/g <output &&
 	test_grep -Fx untracked/h <output'


### PR DESCRIPTION
Some tests were failing on my system, so I marked them as failing (since I don't know how to fix them myself).

### Verbose output of failing tests

```sh
not ok 7 - list-untracked -r works with one empty repo
#       {
#                       echo a &&
#                       echo b &&
#                       echo part/e &&
#                       echo part/f &&
#                       echo tracked/c &&
#                       echo tracked/d &&
#                       echo untracked/g &&
#                       echo untracked/h
#               } >expected &&
#               $VCSH list-untracked -r >output &&
#               test_cmp expected output
# setup: Add some files to repository
```
```sh
not ok 10 - list-untracked -r shows contents of completely untracked directory
#       $VCSH list-untracked -r >output &&
#               test_grep -Fx untracked/g <output &&
#               test_grep -Fx untracked/h <output
```

### Output of `vcsh list-untracked -r`

```
fatal: empty string is not a valid pathspec. please use . instead if you meant to match all paths
fatal: empty string is not a valid pathspec. please use . instead if you meant to match all paths
```

### Environment info

* Operating System: `Antergos 4.18.5-arch1-1-ARCH x86_64`
* `prove` version: `TAP::Harness v3.42 and Perl v5.28.0`
* `git` version: `git version 2.18.0`
